### PR TITLE
Fix terming new teams

### DIFF
--- a/Controls/TeamBox.cs
+++ b/Controls/TeamBox.cs
@@ -524,7 +524,7 @@ namespace Torn.UI
 					}
 				}
 			}
-			ListView.Columns[1].Text = (yellows > 0 ? yellows + "Y " : "") + (reds > 0 ? reds + "R " : "") + leagueTeam.Name;
+			ListView.Columns[1].Text = (yellows > 0 ? yellows + "Y " : "") + (reds > 0 ? reds + "R " : "") + (leagueTeam?.Name ?? "Players");
 		}
     }
 


### PR DESCRIPTION
Ensures that terms can still be applied to teams that have yet to be identified by Torn

Addresses TORN-1